### PR TITLE
WIP: Add "1st clocked in" to status line

### DIFF
--- a/dit/dit_exporter.py
+++ b/dit/dit_exporter.py
@@ -191,6 +191,7 @@ def task(group, group_id, subgroup, subgroup_id, task, task_id, data):
         _overall_time_spent += time_spent
 
         if statussing and not verbose:
+            first_entry = logbook[0]
             log = logbook[-1]
             string = '  '
 
@@ -199,10 +200,11 @@ def task(group, group_id, subgroup, subgroup_id, task, task_id, data):
 
             if time_spent:
                 string += "%s %s. " % (_ce('Spent'), td2str(time_spent))
+            string += "\n  %s %s." % (_ce('First clocked in at'), dt2str(first_entry['in']))
             if log['out']:
-                string += "%s %s." % (_ce('Clocked out at'), dt2str(log['out']))
+                string += "\n  %s %s." % (_ce('Clocked out at'), dt2str(log['out']))
             else:
-                string += "%s %s." % (_cf('Clocked in at'), dt2str(log['in']))
+                string += "\n  %s %s." % (_cf('Clocked in at'), dt2str(log['in']))
             _write(string)
 
         else:


### PR DESCRIPTION
Flagged as WIP because I've not updated the test files.

Whenever I'm pushing hours to Gitlab, I find it useful to know what was the 1st clocked in date.

Since the status line became too big, I've split it into 3. Sample below.

![screenshot_2019-02-18_10-54-55](https://user-images.githubusercontent.com/3093121/52955564-be602500-336b-11e9-8d75-dd745c40b18e.png)
